### PR TITLE
Simplify 2d Context `.putImageData()` code example

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md
@@ -77,42 +77,20 @@ of {{domxref("CanvasRenderingContext2D.fillRect()")}}.
 const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
 
-function putImageData(
-  ctx,
-  imageData,
-  dx,
-  dy,
-  dirtyX,
-  dirtyY,
-  dirtyWidth,
-  dirtyHeight,
-) {
-  const data = imageData.data;
-  const height = imageData.height;
-  const width = imageData.width;
-  dirtyX = dirtyX || 0;
-  dirtyY = dirtyY || 0;
-  dirtyWidth = dirtyWidth !== undefined ? dirtyWidth : width;
-  dirtyHeight = dirtyHeight !== undefined ? dirtyHeight : height;
-  const limitBottom = dirtyY + dirtyHeight;
-  const limitRight = dirtyX + dirtyWidth;
-  for (let y = dirtyY; y < limitBottom; y++) {
-    for (let x = dirtyX; x < limitRight; x++) {
-      const pos = y * width + x;
-      ctx.fillStyle = `rgba(${data[pos * 4 + 0]}, ${data[pos * 4 + 1]}, ${
-        data[pos * 4 + 2]
-      }, ${data[pos * 4 + 3] / 255})`;
-      ctx.fillRect(x + dx, y + dy, 1, 1);
-    }
-  }
-}
-
-// Draw content onto the canvas
+// Draw a black square onto the canvas in the top left corner:
 ctx.fillRect(0, 0, 100, 100);
-// Create an ImageData object from it
-const imagedata = ctx.getImageData(0, 0, 100, 100);
-// use the putImageData function that illustrates how putImageData works
-putImageData(ctx, imagedata, 150, 0, 50, 50, 25, 25);
+
+// Create an ImageData object to save the current canvas.
+const savedCanvas = ctx.getImageData(0, 0, 100, 100);
+
+// Erase the canvas
+ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+// Ex.1: Use putImageData() to repaint canvas using the saved ImageData, but translate it +10 horizontally and vertically from original coordinates:
+ctx.putImageData(savedCanvas, 10, 10);
+
+// Ex.2. Advanced use of putImageData() to move as well as rescale the ImageData snapshot
+ctx.putImageData(savedCanvas, 150, 0, 50, 50, 25, 25);
 ```
 
 #### Result


### PR DESCRIPTION
### Description

The first code example on https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/putImageData for the Canvas-2d-context `putImageData()` function is oddly contrived.

Instead of directly demonstrating the use of `context.putImageData()`, the example first creates a function in the global scope to augment the native-function's arguments, adds default protections, and adds color functionality that is not native to `putImageData()`

### Motivation

To hopefully clarify the native use of the `.putImageData()` function.

### Additional details

N/A

### Related issues and pull requests

N/A

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
